### PR TITLE
Revert "hlte-common: Disable sdcardfs"

### DIFF
--- a/system_prop.mk
+++ b/system_prop.mk
@@ -65,7 +65,7 @@ PRODUCT_PROPERTY_OVERRIDES += \
 
 # Storage
 PRODUCT_PROPERTY_OVERRIDES += \
-    ro.sys.sdcardfs=false
+    ro.sys.sdcardfs=true
 
 # Wifi
 PRODUCT_PROPERTY_OVERRIDES += \


### PR DESCRIPTION
This reverts commit 555cfeba18f45a1867fa24336af16acc63f731dd.

* The cause for the apparent space leak (until unmount) is caused by
  asymmetric access by Android to the upper vs. lower filesystems on
  external storage and the fact that sdcardfs maintained upper/lower
  icache and dcache that are not synched. While normally only visible
  to users on external sdcards, it could be forced on internal storage
  by twiddling /data/media/0 and /sdcard.
* See https://review.lineageos.org/#/c/193137/ for resolution.

Change-Id: Ic0141a2129adffaa0c260bea412f802b29fdc90e