### PR TITLE
hlte-common: Remove libsecril-client*

### DIFF
--- a/hlte.mk
+++ b/hlte.mk
@@ -116,9 +116,7 @@ PRODUCT_COPY_FILES += \
 
 # Radio
 PRODUCT_PACKAGES += \
-    libsecnativefeature \
-    libsecril-client-sap \
-    libsecril-client
+    libsecnativefeature
 
 # Ramdisk
 PRODUCT_PACKAGES += \


### PR DESCRIPTION
* These are only required for some OEM blobs, and not even any
  that we make use of:
  * system/bin/at_distributor matches
  * system/bin/connfwexe matches
  * system/bin/smdexe matches
  * system/bin/wpa_supplicant matches
  * system/lib/hw/audio.primary.msm8974.so matches
  * system/lib/hw/lights.msm8974.so matches
  * system/lib/libaudio-ril.so matches
  * system/lib/libbluetooth_jni.so matches
  * system/lib/libsecril-client.so matches

Change-Id: I7488681c9c1c15c1a42ba9a718c426c80526db19